### PR TITLE
Use task provider and region in download task

### DIFF
--- a/src/main/groovy/com/github/mgk/gradle/S3Plugin.groovy
+++ b/src/main/groovy/com/github/mgk/gradle/S3Plugin.groovy
@@ -98,7 +98,7 @@ class S3Download extends S3Task {
 
     @TaskAction
     def task() {
-        TransferManager tm = new TransferManager()
+        TransferManager tm = new TransferManager(getS3Client())
         Transfer transfer
         Path temp
 


### PR DESCRIPTION
This is basically a subset of the changes in [this PR](https://github.com/mgk/s3-plugin/pull/7) so that profiles set by the s3 config object are respected in the Download task. 