### PR TITLE
Use explicit getter for S3Upload#overwrite

### DIFF
--- a/src/main/groovy/com/github/mgk/gradle/S3Plugin.groovy
+++ b/src/main/groovy/com/github/mgk/gradle/S3Plugin.groovy
@@ -72,7 +72,13 @@ class S3Upload extends S3Task {
     String file
 
     @Input
-    boolean overwrite = false
+    boolean getOverwrite() {
+        _overwrite
+    }
+    boolean setOverwrite(boolean value) {
+        _overwrite = value
+    }
+    private boolean _overwrite
 
     @TaskAction
     def task() {


### PR DESCRIPTION
Avoids the "redundant getters" validation failure when using Gradle 7.

https://docs.gradle.org/7.3.3/userguide/validation_problems.html#redundant_getters