### PR TITLE
Configure source/target compatibility in the "java" extensions on the build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ repositories {
     jcenter()
 }
 
+java {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+}
+
 if (System.env.TRAVIS == 'true') {
     def branch = System.env.TRAVIS_BRANCH.replace('/', '-')
     def isPullRequestBuild = System.env.TRAVIS_PULL_REQUEST != 'false'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,5 @@
 group = com.github.mgk.gradle
 version = 1.5.1
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 publishPluginVersion = 1.1.0
 awsSdkS3Version = 1.11.783


### PR DESCRIPTION
Looks like defining this in Gradle properties is not picked up by recent Gradle versions. I tried using version 1.6.0 in a build running on Java 11, and got:

```
10:38:17  Caused by: org.gradle.internal.component.NoMatchingGraphVariantsException: No matching variant of com.github.mgk.gradle:s3:1.6.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 11, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.5' but:
10:38:17    - Variant 'apiElements' capability com.github.mgk.gradle:s3:1.6.0 declares a library, packaged as a jar, and its dependencies declared externally:
10:38:17        - Incompatible because this component declares a component for use during compile-time, compatible with Java 17 and the consumer needed a component for use during runtime, compatible with Java 11
10:38:17        - Other compatible attribute:
10:38:17            - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
```

After the changes in this PR, I did a smoke test and Gradle running on Java 11 was able to load the plugin.

I wasn't sure whether to target `main` or `develop`. I branched from `develop`. Let me know if I should rebase.